### PR TITLE
Fixed overloading on GetTimeOffset. Errors when sunrise or sunset is null.

### DIFF
--- a/src/Zmanim/AstronomicalCalendar.cs
+++ b/src/Zmanim/AstronomicalCalendar.cs
@@ -451,14 +451,14 @@ namespace Zmanim
         /// </returns>
         public virtual DateTime? GetTimeOffset(DateTime time, long offset)
         {
-            if (time == null || offset == long.MinValue)
-                return null;
-
             return time.AddMilliseconds(offset);
         }
 
         protected virtual DateTime? GetTimeOffset(DateTime? time, long offset)
         {
+            if (time == null || offset == long.MinValue)
+                return null;
+
             return GetTimeOffset(time.Value, offset);
         }
 


### PR DESCRIPTION
AstronomicalCalendar.GetTimeOffset is improperly overloaded. If a day has no sunrise or sunset, instead of returning null as expected, it will throw `System.InvalidOperationException : Nullable object must have a value.` on accessing DateTime.Value.

Reproduce with location as Fairbanks, Alaska on 6/20/2016. GetMinchaGedola16Point1Degrees, as well as 17 other methods, throw an error.

Not sure why GitHub's diffing is having problems here. Should be +4/-4 or thereabouts.
